### PR TITLE
Add rocket suite with parameters.

### DIFF
--- a/suites/parameters/README
+++ b/suites/parameters/README
@@ -1,0 +1,2 @@
+Version of the tutorial 'rocket' suite using parameterized tasks instead of
+Jinja2 loops.

--- a/suites/parameters/bin/detonate
+++ b/suites/parameters/bin/detonate
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -eu
+
+TERM=$(ls -drt -1 /dev/pts/* | tail -1); START=$((RANDOM%40 + 20))
+for i in {0..2}; do
+    printf "\r\033[2K %-"$((START-${#SOUND}/2))"s\033[1;3${COLOUR_CODE}m $SOUND \033[0m\r" " " > $TERM
+    SOUND=$(echo $SOUND | sed "s/\([^ ]\)/\1 /g")
+    sleep 0.15
+done

--- a/suites/parameters/rose-suite.conf
+++ b/suites/parameters/rose-suite.conf
@@ -1,0 +1,3 @@
+[jinja2:suite.rc]
+ROCKET_NUMBER = 30
+ROCKET_SOUNDS = ["BANG", "WHOOSH"]

--- a/suites/parameters/suite.rc
+++ b/suites/parameters/suite.rc
@@ -1,0 +1,34 @@
+#!jinja2
+[cylc]
+    UTC mode = True # Ignore DST
+    [[parameters]]
+        rn = 0..{{ ROCKET_NUMBER - 1}}  # NOTE: assumed between 20 and 100.
+        rn1 = 0..{{ ROCKET_NUMBER // 2 }}
+        rn2 = {{ 1 + ROCKET_NUMBER // 2 }}..{{ ROCKET_NUMBER - 1 }}
+    [[parameter templates]]
+        rn = _%(rn)s
+        rn1 = _%(rn1)s
+        rn2 = _%(rn2)s
+[scheduling]
+    [[dependencies]]
+        graph = """start => ignite_rocket<rn=0>
+            ignite_rocket<rn1-1> => ignite_rocket<rn1>
+            ignite_rocket<rn1={{ROCKET_NUMBER // 2}}> => ignite_rocket<rn2>
+            ignite_rocket<rn> => detonate_rocket<rn> => stop"""
+[runtime]
+    [[IGNITE]]
+        script = sleep $((RANDOM % 2))
+    [[DETONATE]]
+        script = detonate  # Diverge from the online tutorial - use a script instead.
+    [[ignite_rocket<rn>]]
+        inherit = IGNITE
+    [[detonate_rocket<rn>]]
+        inherit = DETONATE
+        pre-script = """SOUNDS=( {{ROCKET_SOUNDS | join(' ') }} )  # bash array
+rn=$((10#$CYLC_TASK_PARAM_rn))  # interpret 0-padded as decimal, not octal
+export COLOUR_CODE=$(( $rn % 5 + 1 ))
+export SOUND=${SOUNDS[ $(( rn % 2 )) ]}"""
+    [[start]]
+    [[stop]]
+        script = """
+sleep 2 && printf '\033[2K' > $(ls -drt -1 /dev/pts/* | tail -1)"""


### PR DESCRIPTION
Even though the rocket suite has non-trivial Jinja2 loops (over partial ranges) it can be done with parameters. I'm not sure I'd suggest replacing the original (although I would if it was a more straightforward suite with simple loops), but it might be instructive to include both? 
